### PR TITLE
Fix double newlines

### DIFF
--- a/autoresponse.js
+++ b/autoresponse.js
@@ -9,10 +9,9 @@ module.exports = [
             "title": "Adding a Favicon to v2",
             "footer": "",
             "body": [
-                "1. Make sure your favicon is named `favicon.ico` (note the .ico format - for example don't rename a .png to a .ico)\n",
-                "2. Upload the favicon to the root directory. (public_html, htdocs or /var/www/html)\n",
-                "3. If you still can't see it on your website, try forcing a browser cache refresh by viewing your site and pressing `Ctrl + F5` on windows or `Cmd + Shift + R` on macos.\n",
-                "And if you're using Cloudflare, don't forget to purge cache there as well."
+                "1. Make sure your favicon is named `favicon.ico` (note the .ico format - for example don't rename a .png to a .ico)",
+                "2. Upload the favicon to the root directory. (public_html, htdocs or /var/www/html)",
+                "3. If you still can't see it on your website, try forcing a browser cache refresh by viewing your site and pressing `Ctrl + F5` on Windows/Linux or `Cmd + Shift + R` on MacOS. And if you're using Cloudflare, don't forget to purge cache there as well."
             ]
         }
     },
@@ -22,14 +21,13 @@ module.exports = [
         keywords: ["The requested URL was not found on this server."],
         response: {
             "title": "Friendly Urls",
-            "footer": "",
+            "footer": "To disable friendly urls, go to `core/config.php` and change \"friendly\" from \"true\" to \"false\".",
             "body": [
-                "In order to use friendly urls on your v2 website, your web server has to allow the use of `.htaccess` files and you have to have `mod_rewrite` enabled.\n\n",
-                "You can check if `mod_rewrite` is enabled by going to http://example.com/rewrite_test if it says \"Rewrite Enabled\" you're good to go.\n",
-                "If not, contact your web host and ask them to enable `mod_rewrite`, or if you're using a vps or a dedicated server, Google information on how to enable `mod_rewrite` on your specific OS.\n\n",
-                "As well make sure you have a `.htaccess` file in your root directory, `.htaccess` files are hidden so make sure you have hidden file view enabled on your file manager or ftp client.\n",
-                "Your `.htaccess` file should contain these rules: https://raw.githubusercontent.com/NamelessMC/Nameless/v2/.htaccess\n\n",
-                "To disable friendly urls, go to `core/config.php` and change \"friendly\" from \"true\" to \"false\"."
+                "In order to use friendly urls on your v2 website, your web server has to allow the use of `.htaccess` files and you have to have `mod_rewrite` enabled. You can check if `mod_rewrite` is enabled by going to http://example.com/rewrite_test if it says \"Rewrite Enabled\" you're good to go.",
+                "",
+                "If not, contact your web host and ask them to enable `mod_rewrite`, or if you're using a vps or a dedicated server, Google information on how to enable `mod_rewrite` on your specific OS.",
+                "",
+                "As well make sure you have a `.htaccess` file in your root directory, `.htaccess` files are hidden so make sure you have hidden file view enabled on your file manager or ftp client. Your `.htaccess` file should contain these rules: https://raw.githubusercontent.com/NamelessMC/Nameless/v2/.htaccess\n\n",
             ]
         }
     },
@@ -41,8 +39,8 @@ module.exports = [
             "title": "Incompatible module",
             "footer": "",
             "body": [
-                "It seems like the module you are trying to enable is **not compatible** with your template! You can do 2 things:\n\n",
-                "- Ask the developer of the template you use to add compatibility for it\n",
+                "It seems like the module you are trying to enable is **not compatible** with your template! You can do 2 things:",
+                "- Ask the developer of the template you use to add compatibility for it",
                 "- Use a different template that is compatible"
             ]
         }
@@ -65,10 +63,12 @@ module.exports = [
             "title": "Unable To Load Template File",
             "footer": "",
             "body": [
-               "When you get an error that says \"Unable to load template file:\" `module-name/some-file.tpl` or `some-file.tpl`, it means that either your panel template or your website template (depending on where the error occurs), is missing that module's template file(s).\n\n",
-               "If you're using the \"DefaultRevamp\" template, the template file(s) for that module should be included in the module's download folder.\n\n",
-               "If you're using a premium template, the module template files should've already been included with the template, if they are not, contact the template author.\n",
-               "For the free templates, module support is usually pretty shaky, and possibilty for the module support being added is pretty low.\n\n",
+               "When you get an error that says \"Unable to load template file:\" `module-name/some-file.tpl` or `some-file.tpl`, it means that either your panel template or your website template (depending on where the error occurs), is missing that module's template file(s).",
+               "",
+               "If you're using the \"DefaultRevamp\" template, the template file(s) for that module should be included in the module's download folder.",
+               "",
+               "For custom templates, with premium templates the module template files should've already been included with the template, if they are not, contact the template author. For free templates, module support is usually pretty shaky, and possibilty for the module support being added is pretty low.",
+               "",
                "Most panel templates in the resources page at this time don't support most modules, so you should either wait for the support to be added or use the \"Default\" panel template instead."
            ]
         }
@@ -93,8 +93,9 @@ module.exports = [
             "title": "Folder is not writeable",
             "footer" : "",
             "body": [
-                "This is usually caused by the installation folder within the web root (and its subdirectories) not being writable. You will need to modify the permissions recursively of the folder so the process running PHP can write to it.\n",
-                "An example command for Apache and nginx on Ubuntu is\n",
+                "This is usually caused by the installation folder within the web root (and its subdirectories) not being writable. You will need to modify the permissions recursively of the folder so the process running PHP can write to it.",
+                "",
+                "An example command for Apache and nginx on Ubuntu is:",
                 "`sudo chown -R www-data:www-data /var/www/html/`"
             ]
         }
@@ -107,9 +108,7 @@ module.exports = [
             "title": "Invalid token",
             "footer": "",
             "body": [
-                "This error will likely occur when your template is outdated. This is due to a change in pr12 which causes issues causing this error.\n",
-                "To fix this, update your template to the most recent version if it is available (it should support pr12). If your template has not been updated yet,",
-                "try switching to the default template to fix the issue temporarily. After this, attempt to clear your panel template cache."
+                "This error will likely occur when your template is outdated. This is due to a change in pr12 which causes issues causing this error. To fix this, update your template to the most recent version if it is available (it should support pr12). If your template has not been updated yet, try switching to the default template to fix the issue temporarily. After this, attempt to clear your panel template cache."
             ]
         }
     },
@@ -121,12 +120,10 @@ module.exports = [
             "title": "Proper file permissions",
             "footer": "",
             "body": [
-                "Setting the permission mode of a file to 777 means all users on a system will get full read, write and execute permissions. This is never a good solution.\n",
-                "\n",
-                "When you installed your webserver, a dedicated user was automatically created on your system. On nearly all systems it's `www-data`, but ",
-                "it can also be `nginx`, `apache`, `www`, or something else. The `chmod -R` command can be used to recursively change ownership of a directory and its ",
-                "contents. Replace `/var/www/html` with the path to your NamelessMC installation directory.\n",
-                "\n",
+                "Setting the permission mode of a file to 777 means all users on a system will get full read, write and execute permissions. This is never a good solution.",
+                "",
+                "When you installed your webserver, a dedicated user was automatically created on your system. On nearly all systems it's `www-data`, but it can also be `nginx`, `apache`, `www`, or something else. The `chmod -R` command can be used to recursively change ownership of a directory and its contents. Replace `/var/www/html` with the path to your NamelessMC installation directory.",
+                "",
                 "Example: `chown -R www-data: /var/www/html`"
             ]
         }


### PR DESCRIPTION
The bot already sends a newline character after every autoresponse line, so including "\n" in bot configuration is unnecessary. Before this commit, messages had weird redundant word wrapping and two or sometimes three blank lines between paragraphs. 